### PR TITLE
revert RxRpcClient observer complete in order to avoid invocation mul…

### DIFF
--- a/src/lib/rxrpc-client.ts
+++ b/src/lib/rxrpc-client.ts
@@ -47,7 +47,7 @@ export class RxRpcClient extends RxRpcInvoker {
                             connection => {
                                 self.onConnected(connection);
                                 observer.next(connection);
-                                //observer.complete();
+                                observer.complete();
                                 },
                             error => observer.error(error),
                             () => observer.complete());


### PR DESCRIPTION
…tiple sent on different connections

Without this code, RxRpcClient can potentially emit several connections (in case of reconnect flow) which then can cause old invocations to be sent again on a new emitted connection. This can also cause a memory leak because javascript can't free passed invocation due to active closure in the send method.

The observe.complete can be safely used just as we use it on line 43 (in case of an already existing connection), and is not causing the reconnect mechanism to fail. The complete is done after the onConnected call which stores the connection (line 48).

Tested and verified on WebUI project.