### PR TITLE
Update rxrpc-client.ts

### DIFF
--- a/src/lib/rxrpc-client.ts
+++ b/src/lib/rxrpc-client.ts
@@ -1,5 +1,5 @@
 import {defer, interval, Observable, of, OperatorFunction, Subject, throwError} from 'rxjs';
-import {distinctUntilChanged, finalize, flatMap, refCount, shareReplay, takeUntil, takeWhile} from 'rxjs/operators'
+import {distinctUntilChanged, finalize, flatMap, refCount, share, shareReplay, takeUntil, takeWhile} from 'rxjs/operators'
 import {Response} from './data/response';
 import {Result} from './data/result';
 import {Invocation, Invocations} from './data/invocation';
@@ -53,7 +53,7 @@ export class RxRpcClient extends RxRpcInvoker {
                             () => observer.complete());
                 }
             })
-            .pipe(shareReplay({bufferSize: 1, refCount: false}))
+            .pipe(share())
     }
 
     public observeConnected(): Observable<boolean> {


### PR DESCRIPTION
Replace shareReplay with share becasue JavaScript does not support multi-threading because the JavaScript interpreter in the browser is a single thread (AFAIK). Even Google Chrome will not let a single web page's JavaScript run concurrently because this would cause massive concurrency issues in existing web pages.
Also we saw that it working as expected using log prints.