### PR TITLE
Failed invocation throws error when failed to connect

### DIFF
--- a/src/lib/rxrpc-client.ts
+++ b/src/lib/rxrpc-client.ts
@@ -77,8 +77,8 @@ export class RxRpcClient extends RxRpcInvoker {
                     this.listeners.forEach(l => l.onInvocation(invocation));
                     connection.send(invocation);
                 }, error => {
-                    this.currentConnection.error(error);
-                    this.close();
+                    this.currentConnection?.error(error);
+                    this.close(error);
                 }))
     }
 
@@ -139,15 +139,16 @@ export class RxRpcClient extends RxRpcInvoker {
         return JSON.stringify(subscription);
     }
 
-    public close() {
+    public close(error: any = null) {
         if (this.isConnected()) {
-            this.currentConnection.close();
-            this.onDisconnected();
+            this.currentConnection?.close();
+
         }
+        this.onDisconnected(error);
     }
 
     private isConnected(): boolean {
-        return this.currentConnection && true;
+        return !!this.currentConnection;
     }
 
     private send(invocation: Invocation) {


### PR DESCRIPTION
There is a use-case, when transport failed to connect. 

In that case, when endpoint is invoked, it tries to establish the connection. 

Once the connection fails, there is an error handler that triggers `this.currentConnection.error(error);`
Since currectConnection does not exist (yet), handler throws js error and stops.

There are 2 major fixes:

1. CurrentConnection fixed to be optional

2. Invocation error was triggered only when a connection exists. If a connection does not exist there is no error propagated. 
onDisconnected triggered when connectionFailed